### PR TITLE
Fix Mac OS compilation

### DIFF
--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -141,7 +141,7 @@ endif	# WANT_WIN_X11
 
 ifdef WANT_WIN_QT
 QT_FRAMEWORKS_DIR = /Library/Frameworks
-CFLAGS += -DQT_GRAPHICS -DNOUSER_SOUNDS -DZLIB_COMP -mmacosx-version-min=10.5
+CFLAGS += -DQT_GRAPHICS -DNOUSER_SOUNDS -DZLIB_COMP -mmacosx-version-min=10.10
 ifdef WANT_QT_FROM_HOMEBREW
 CFLAGS += $(shell pkg-config --cflags QtCore QtGui)
 WINLIB += $(shell pkg-config --libs QtCore QtGui)

--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -150,6 +150,7 @@ else # !WANT_QT_FROM_HOMEBREW
 CFLAGS += -F$(QT_FRAMEWORKS_DIR)
 WINLIB += -F$(QT_FRAMEWORKS_DIR) -framework QtCore -framework QtGui
 endif # !WANT_QT_FROM_HOMEBREW
+MOC = $(QTDIR)/bin/moc
 LINK=$(CXX)
 WINSRC += $(WINQT4SRC)
 WINOBJ0 += $(WINQT4OBJ) /usr/lib/libz.dylib


### PR DESCRIPTION
* Support new SDL2 that enforces Mac > 10.6 (but we'll use 10.10 since the whole file is 10.10+)
* Define $(MOC) (broken in 7f28325 / fe95177)