### PR TITLE
Enable QT5 for Mac

### DIFF
--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -160,7 +160,7 @@ GNOMEINC=-I/usr/lib/glib/include -I/usr/lib/gnome-libs/include -I../win/gnome
 # The Qt and Be window systems are written in C++, while the rest of
 # NetHack is standard C.  If using Qt, uncomment the LINK line here to get
 # the C++ libraries linked in.
-CXXFLAGS = $(CFLAGS) -I. -I$(QTDIR)/include
+CXXFLAGS = $(CFLAGS) -I. -I$(QTDIR)/include -std=c++11
 ifndef CXX
 CXX=g++
 endif

--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -141,7 +141,7 @@ endif	# WANT_WIN_X11
 
 ifdef WANT_WIN_QT
 QT_FRAMEWORKS_DIR = /Library/Frameworks
-CFLAGS += -DQT_GRAPHICS -DNOUSER_SOUNDS -DZLIB_COMP -mmacosx-version-min=10.5
+CFLAGS += -DQT_GRAPHICS -DNOUSER_SOUNDS -DZLIB_COMP -mmacosx-version-min=10.10
 ifdef WANT_QT_FROM_HOMEBREW
 CFLAGS += $(shell pkg-config --cflags QtCore QtGui)
 WINLIB += $(shell pkg-config --libs QtCore QtGui)

--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -32,6 +32,14 @@ WANT_DEFAULT=curses
 #     library installation root.  (Qt2 or Qt3 will not work.)
 ifdef WANT_WIN_QT
 QTDIR=/usr
+#HAVE_QT5=1
+ifdef HAVE_QT5
+    QT_PACKAGES = Qt5Gui Qt5Widgets
+    QT_CORE = Qt5Core
+else
+    QT_PACKAGES = QtGui
+    QT_CORE = QtCore
+endif
 endif	# WANT_WIN_QT
 
 # 1c. Was SDL2 installed in /Library/Frameworks (default) or via Homebrew?
@@ -143,9 +151,9 @@ ifdef WANT_WIN_QT
 QT_FRAMEWORKS_DIR = /Library/Frameworks
 CFLAGS += -DQT_GRAPHICS -DNOUSER_SOUNDS -DZLIB_COMP -mmacosx-version-min=10.10
 ifdef WANT_QT_FROM_HOMEBREW
-CFLAGS += $(shell pkg-config --cflags QtCore QtGui)
-WINLIB += $(shell pkg-config --libs QtCore QtGui)
-QTDIR = $(shell pkg-config --variable=prefix QtCore)
+CFLAGS += $(shell pkg-config --cflags $(QT_CORE) $(QT_PACKAGES) )
+WINLIB += $(shell pkg-config --libs $(QT_CORE) $(QT_PACKAGES) )
+QTDIR = $(shell pkg-config --variable=prefix $(QT_CORE))
 else # !WANT_QT_FROM_HOMEBREW
 CFLAGS += -F$(QT_FRAMEWORKS_DIR)
 WINLIB += -F$(QT_FRAMEWORKS_DIR) -framework QtCore -framework QtGui

--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -150,6 +150,7 @@ else # !WANT_QT_FROM_HOMEBREW
 CFLAGS += -F$(QT_FRAMEWORKS_DIR)
 WINLIB += -F$(QT_FRAMEWORKS_DIR) -framework QtCore -framework QtGui
 endif # !WANT_QT_FROM_HOMEBREW
+MOC = $(QTDIR)/bin/moc
 LINK=$(CXX)
 WINSRC += $(WINQT4SRC)
 WINOBJ0 += $(WINQT4OBJ) /usr/lib/libz.dylib

--- a/sys/unix/hints/macosx10.10
+++ b/sys/unix/hints/macosx10.10
@@ -32,7 +32,7 @@ WANT_DEFAULT=curses
 #     library installation root.  (Qt2 or Qt3 will not work.)
 ifdef WANT_WIN_QT
 QTDIR=/usr
-#HAVE_QT5=1
+HAVE_QT5=1
 ifdef HAVE_QT5
     QT_PACKAGES = Qt5Gui Qt5Widgets
     QT_CORE = Qt5Core


### PR DESCRIPTION
This PR depends on #9. Note that I had to change one file that's not Mac-only; I don't think it should cause problems, but sys/unix/Makefile.src is reseting `CXXFLAGS`, so I couldn't set it in the macos hints file, the way we set CFLAGS. Please confirm that this doesn't break QT5 on Linux or elsewhere before merging.